### PR TITLE
Show clear error message if authentication failed (CLI)

### DIFF
--- a/cli/lib/ghuls/cli.rb
+++ b/cli/lib/ghuls/cli.rb
@@ -41,6 +41,10 @@ module GHULS
 
       parse_options(args)
       config = Utilities.configure_stuff(@opts)
+      if config == false then
+        puts 'Error: authentication failed, check your username/password or token'
+        exit
+      end
       @gh = config[:git]
       @colors = config[:colors]
     end

--- a/cli/lib/ghuls/cli.rb
+++ b/cli/lib/ghuls/cli.rb
@@ -41,7 +41,7 @@ module GHULS
 
       parse_options(args)
       config = Utilities.configure_stuff(@opts)
-      if config == false then
+      if config == false
         puts 'Error: authentication failed, check your username/password or token'
         exit
       end


### PR DESCRIPTION
Before this commit, the application just crashed with an error that didn't say anything about what was wrong; now it tells the user that the authentication failed.
