### PR TITLE
Case-insensitive repo contributor check

### DIFF
--- a/utils/utilities.rb
+++ b/utils/utilities.rb
@@ -60,7 +60,7 @@ module Utilities
       next if r[:fork]
       contributors = github.contributors(r[:full_name])
       contributors.each do |c|
-        if c[:login] == username
+        if c[:login].casecmp(username).nonzero?
           true_repos.push(r[:full_name])
         else
           next


### PR DESCRIPTION
Before this commit, organization stats were broken if you didn't pass the username with the correct capitalization, because of a case-sensitive equality check. Now, this check is case-insensitive.
