### PR TITLE
Add anchors to contributors regex

### DIFF
--- a/utils/utilities.rb
+++ b/utils/utilities.rb
@@ -60,7 +60,7 @@ module Utilities
       next if r[:fork]
       contributors = github.contributors(r[:full_name])
       contributors.each do |c|
-        if c[:login] =~ /#{username}/i
+        if c[:login] =~ /^#{username}$/i
           true_repos.push(r[:full_name])
         else
           next


### PR DESCRIPTION
`NotProgramFOX123 =~ /ProgramFOX/i` does not return `nil` (which is what we need here), but it does for `/^ProgramFOX$/i`, so I added the anchors to be sure that GHULS doesn't match too many users. For most users, this would not have caused a problem, but for users with very short names it could be that their name is part of a name of another organization member.
